### PR TITLE
Fix illegal utf-8 character

### DIFF
--- a/customtkinter/windows/widgets/core_rendering/draw_engine.py
+++ b/customtkinter/windows/widgets/core_rendering/draw_engine.py
@@ -469,7 +469,7 @@ class BorderedRoundedRect(BaseShape):
         # |@@@@@@    |                   |@@@@@@@@@|
         # |@@@@@@    |                   |@@@@@@@@@|
         spacing = max(
-            self.info.get("corner_radius", 0) - self.info["inner_corner_radius"] * 0.7071, #cos(45°)
+            self.info.get("corner_radius", 0) - self.info["inner_corner_radius"] * 0.7071, #cos(45 degrees)
             border_width
         )
         if abs(spacing - self.info.get("inscribed_spacing", -1000)) > self.spacings_tolerance:


### PR DESCRIPTION
The non-UTF-8 character in the cos comment causes Windows build to fail. Simple fix attached.
```
SyntaxError: Non-UTF-8 code starting with '\xb0' on line 472, but no encoding declared; see https://peps.python.org/pep-0263/ for details
```
Replaces #5 