### PR TITLE
Tooltips multimonitor

### DIFF
--- a/customtkinter/windows/widgets/ctk_tooltip.py
+++ b/customtkinter/windows/widgets/ctk_tooltip.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
+import sys
 import tkinter
 from typing import Any, Callable, Iterable
 from typing_extensions import Literal, Unpack
@@ -269,37 +272,81 @@ class CTkToolTip(CTkFloatingFrame):
                             f"callable returning them, not {type(target)}.")
         return string
 
+    def _get_monitor_rect(self, x: int, y: int) -> tuple[int, int, int, int]:
+        """Return (left, top, right, bottom) of the physical monitor containing (x, y)."""
+        try:
+            if sys.platform.startswith("win"):
+                from ctypes import windll, wintypes, Structure, byref
+
+                class _RECT(Structure):
+                    _fields_ = [("left", wintypes.LONG), ("top", wintypes.LONG),
+                                ("right", wintypes.LONG), ("bottom", wintypes.LONG)]
+
+                class _MONITORINFO(Structure):
+                    _fields_ = [("cbSize", wintypes.DWORD), ("rcMonitor", _RECT),
+                                ("rcWork", _RECT), ("dwFlags", wintypes.DWORD)]
+
+                pt = wintypes.POINT()
+                pt.x, pt.y = x, y
+                monitor = windll.user32.MonitorFromPoint(pt, 2)  # MONITOR_DEFAULTTONEAREST
+                info = _MONITORINFO()
+                info.cbSize = ctypes.sizeof(_MONITORINFO)
+                windll.user32.GetMonitorInfoW(monitor, byref(info))
+                r = info.rcMonitor
+                return r.left, r.top, r.right, r.bottom
+
+            elif sys.platform == "darwin":
+                CG = ctypes.cdll.LoadLibrary(
+                    ctypes.util.find_library("CoreGraphics")
+                    or "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+                )
+                CGPoint = ctypes.c_double * 2
+                point = CGPoint(float(x), float(y))
+                display_ids = (ctypes.c_uint32 * 8)()
+                count = ctypes.c_uint32(0)
+                CG.CGGetDisplaysWithPoint.restype = ctypes.c_int
+                CG.CGGetDisplaysWithPoint(point, 8, display_ids, ctypes.byref(count))
+                display = display_ids[0] if count.value > 0 else CG.CGMainDisplayID()
+                CG.CGDisplayBounds.restype = ctypes.c_double * 4
+                bounds = CG.CGDisplayBounds(display)
+                lft, top, w, h = float(bounds[0]), float(bounds[1]), float(bounds[2]), float(bounds[3])
+                return int(lft), int(top), int(lft + w), int(top + h)
+
+        except Exception:
+            pass
+
+        return 0, 0, self.winfo_vrootwidth(), self.winfo_vrootheight()
+
     def _master_mode(self) -> tuple[int, int, AnchorType]:
         self._toplevel.update_idletasks()
         x_widget = self._widget.winfo_rootx()
         y_widget = self._widget.winfo_rooty()
-        x_negative = x_widget < 0 and self._widget.winfo_pointerx() < 0
-        y_negative = y_widget < 0 and self._widget.winfo_pointery() < 0
         w_widget = self._widget.winfo_width()
         h_widget = self._widget.winfo_height()
         w_frame = self.winfo_reqwidth()
         h_frame = self.winfo_reqheight()
-        w_display = self.winfo_vrootwidth()
-        h_display = self.winfo_vrootheight()
+        mon_left, mon_top, mon_right, mon_bottom = self._get_monitor_rect(
+            x_widget + w_widget // 2, y_widget + h_widget // 2
+        )
         x_offset = self._apply_scaling(self._theme_tt_info["x_offset"])
         y_offset = self._apply_scaling(self._theme_tt_info["y_offset"])
         anchor = self._theme_tt_info["anchor"]
 
         #check if the frame is outside the display horizontally
         if "w" in anchor:
-            if x_widget + x_offset + w_frame + x_offset <= (0 if x_negative else w_display):
+            if x_widget + x_offset + w_frame + x_offset <= mon_right:
                 h_anchor = "w"
             else:
                 h_anchor = "e"
         elif "e" in anchor:
-            if x_widget - x_offset - w_frame - x_offset >= 0 or x_negative:
+            if x_widget - x_offset - w_frame - x_offset >= mon_left:
                 h_anchor = "e"
             else:
                 h_anchor = "w"
         else:
-            if x_widget + round(w_widget / 2) + x_offset + round(w_frame / 2) + x_offset > (0 if x_negative else w_display):
+            if x_widget + round(w_widget / 2) + x_offset + round(w_frame / 2) + x_offset > mon_right:
                 h_anchor = "e"
-            elif x_widget + round(w_widget / 2) - round(w_frame / 2) < 0 and not x_negative:
+            elif x_widget + round(w_widget / 2) - round(w_frame / 2) < mon_left:
                 h_anchor = "w"
             else:
                 h_anchor = ""
@@ -309,22 +356,20 @@ class CTkToolTip(CTkFloatingFrame):
         else:
             x_root = (x_widget + w_widget - x_offset) if h_anchor == "e" else (x_widget + x_offset)
 
-        #if starting position is still outside the display, place it on the edge
-        if x_root > w_display:
-            x_root = w_display - x_offset
-        elif x_root < 0 and not x_negative:
-            x_root = x_offset
-        elif x_root > 0 and x_negative:
-            x_root = -x_offset
+        #if starting position is still outside the display, clamp to monitor edge
+        if x_root > mon_right:
+            x_root = mon_right - x_offset
+        elif x_root < mon_left:
+            x_root = mon_left + x_offset
 
         #check if the frame is outside the display vertically
         if "n" in anchor:
-            if y_widget - y_offset - h_frame - y_offset >= 0 or y_negative:
+            if y_widget - y_offset - h_frame - y_offset >= mon_top:
                 v_anchor = "s"
             else:
                 v_anchor = "n"
         else:
-            if y_widget + h_widget + y_offset + h_frame + y_offset <= (0 if y_negative else h_display):
+            if y_widget + h_widget + y_offset + h_frame + y_offset <= mon_bottom:
                 v_anchor = "n"
             else:
                 v_anchor = "s"

--- a/customtkinter/windows/widgets/ctk_tooltip.py
+++ b/customtkinter/windows/widgets/ctk_tooltip.py
@@ -269,6 +269,18 @@ class CTkToolTip(CTkFloatingFrame):
                             f"callable returning them, not {type(target)}.")
         return string
 
+    def _get_monitor_info(self) -> tuple[int, int, int, int]:
+        try:
+            return get_monitor_info(self._widget.winfo_pointerx(), self._widget.winfo_pointery())
+        except Exception:
+            x_negative = self._widget.winfo_pointerx() < 0
+            y_negative = self._widget.winfo_pointery() < 0
+            mon_left = -1e12 if x_negative else 0
+            mon_top = -1e12 if y_negative else 0
+            mon_right = 0 if x_negative else self.winfo_vrootwidth()
+            mon_bottom = 0 if y_negative else self.winfo_vrootheight()
+            return mon_left, mon_top, mon_right, mon_bottom
+
     def _master_mode(self) -> tuple[int, int, AnchorType]:
         self._toplevel.update_idletasks()
         x_widget = self._widget.winfo_rootx()
@@ -277,17 +289,9 @@ class CTkToolTip(CTkFloatingFrame):
         h_widget = self._widget.winfo_height()
         w_frame = self.winfo_reqwidth()
         h_frame = self.winfo_reqheight()
-        try:
-            mon_left, mon_top, mon_right, mon_bottom = get_monitor_info(
-                self._widget.winfo_pointerx(), self._widget.winfo_pointery()
-            )
-        except Exception:
-            mon_left = 0
-            mon_top = 0
-            mon_right = self.winfo_vrootwidth()
-            mon_bottom = self.winfo_vrootheight()
         x_offset = self._apply_scaling(self._theme_tt_info["x_offset"])
         y_offset = self._apply_scaling(self._theme_tt_info["y_offset"])
+        mon_left, mon_top, mon_right, mon_bottom = self._get_monitor_info()
         anchor = self._theme_tt_info["anchor"]
 
         #check if the frame is outside the display horizontally
@@ -339,10 +343,62 @@ class CTkToolTip(CTkFloatingFrame):
     def _mouse_mode(self) -> tuple[int, int, AnchorType]:
         x_mouse = self._widget.winfo_pointerx()
         y_mouse = self._widget.winfo_pointery()
+        w_frame = self.winfo_reqwidth()
+        h_frame = self.winfo_reqheight()
         x_offset = self._apply_scaling(self._theme_tt_info["x_offset"])
         y_offset = self._apply_scaling(self._theme_tt_info["y_offset"])
-
+        mon_left, mon_top, mon_right, mon_bottom = self._get_monitor_info()
         anchor = self._theme_tt_info["anchor"]
+        screen_edge = False
+
+        if "w" in anchor:
+            if x_mouse + x_offset + w_frame > mon_right:
+                anchor = anchor.replace("w", "e")
+                if "n" in anchor or "s" in anchor:
+                    x_mouse = mon_right
+                    x_offset = 0
+                    screen_edge = True
+
+        elif "e" in anchor:
+            if x_mouse - x_offset - w_frame < mon_left:
+                anchor = anchor.replace("e", "w")
+                if "n" in anchor or "s" in anchor:
+                    x_mouse = mon_left
+                    x_offset = 0
+                    screen_edge = True
+        else:
+            if x_mouse + x_offset + w_frame / 2 > mon_right:
+                anchor = anchor + "e"
+                x_mouse = mon_right
+                x_offset = 0
+            elif x_mouse + x_offset - w_frame / 2 < mon_left:
+                anchor = anchor + "w"
+                x_mouse = mon_left
+                x_offset = 0
+
+        if "n" in anchor:
+            if y_mouse + y_offset + h_frame > mon_bottom:
+                anchor = anchor.replace("n", "s")
+                if ("w" in anchor or "e" in anchor) and not screen_edge:
+                    y_mouse = mon_bottom
+                    y_offset = 0
+
+        elif "s" in anchor:
+            if y_mouse - y_offset - h_frame < mon_top:
+                anchor = anchor.replace("s", "n")
+                if ("w" in anchor or "e" in anchor) and not screen_edge:
+                    y_mouse = mon_top
+                    y_offset = 0
+        else:
+            if y_mouse + y_offset + h_frame / 2 > mon_bottom:
+                anchor = "s" + anchor
+                y_mouse = mon_bottom
+                y_offset = 0
+            elif y_mouse - y_offset - h_frame / 2 < mon_top:
+                anchor = "n" + anchor
+                y_mouse = mon_top
+                y_offset = 0
+
         if "e" in anchor:
             x_offset *= -1
         if "s" in anchor:

--- a/customtkinter/windows/widgets/ctk_tooltip.py
+++ b/customtkinter/windows/widgets/ctk_tooltip.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import ctypes
-import ctypes.util
-import sys
 import tkinter
 from typing import Any, Callable, Iterable
 from typing_extensions import Literal, Unpack
@@ -12,7 +9,7 @@ from .theme import AnchorType, ThemeManager
 from .font import CTkFont
 from .ctk_floating_frame import CTkFloatingFrame, CTkFloatingFrameArgs, CTkFloatingFrameThemedArgs
 from .ctk_label import CTkLabel, CTkLabelArgs
-from .utility import pop_from_dict_by_iterable, check_kwargs_empty
+from .utility import pop_from_dict_by_iterable, check_kwargs_empty, get_monitor_info
 
 
 class CTkToolTipThemedArgs(CTkFloatingFrameThemedArgs, total=False, closed=True):
@@ -272,51 +269,6 @@ class CTkToolTip(CTkFloatingFrame):
                             f"callable returning them, not {type(target)}.")
         return string
 
-    def _get_monitor_rect(self, x: int, y: int) -> tuple[int, int, int, int]:
-        """Return (left, top, right, bottom) of the physical monitor containing (x, y)."""
-        try:
-            if sys.platform.startswith("win"):
-                from ctypes import windll, wintypes, Structure, byref
-
-                class _RECT(Structure):
-                    _fields_ = [("left", wintypes.LONG), ("top", wintypes.LONG),
-                                ("right", wintypes.LONG), ("bottom", wintypes.LONG)]
-
-                class _MONITORINFO(Structure):
-                    _fields_ = [("cbSize", wintypes.DWORD), ("rcMonitor", _RECT),
-                                ("rcWork", _RECT), ("dwFlags", wintypes.DWORD)]
-
-                pt = wintypes.POINT()
-                pt.x, pt.y = x, y
-                monitor = windll.user32.MonitorFromPoint(pt, 2)  # MONITOR_DEFAULTTONEAREST
-                info = _MONITORINFO()
-                info.cbSize = ctypes.sizeof(_MONITORINFO)
-                windll.user32.GetMonitorInfoW(monitor, byref(info))
-                r = info.rcMonitor
-                return r.left, r.top, r.right, r.bottom
-
-            elif sys.platform == "darwin":
-                CG = ctypes.cdll.LoadLibrary(
-                    ctypes.util.find_library("CoreGraphics")
-                    or "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
-                )
-                CGPoint = ctypes.c_double * 2
-                point = CGPoint(float(x), float(y))
-                display_ids = (ctypes.c_uint32 * 8)()
-                count = ctypes.c_uint32(0)
-                CG.CGGetDisplaysWithPoint.restype = ctypes.c_int
-                CG.CGGetDisplaysWithPoint(point, 8, display_ids, ctypes.byref(count))
-                display = display_ids[0] if count.value > 0 else CG.CGMainDisplayID()
-                CG.CGDisplayBounds.restype = ctypes.c_double * 4
-                bounds = CG.CGDisplayBounds(display)
-                lft, top, w, h = float(bounds[0]), float(bounds[1]), float(bounds[2]), float(bounds[3])
-                return int(lft), int(top), int(lft + w), int(top + h)
-
-        except Exception:
-            pass
-
-        return 0, 0, self.winfo_vrootwidth(), self.winfo_vrootheight()
-
     def _master_mode(self) -> tuple[int, int, AnchorType]:
         self._toplevel.update_idletasks()
         x_widget = self._widget.winfo_rootx()
@@ -325,9 +277,15 @@ class CTkToolTip(CTkFloatingFrame):
         h_widget = self._widget.winfo_height()
         w_frame = self.winfo_reqwidth()
         h_frame = self.winfo_reqheight()
-        mon_left, mon_top, mon_right, mon_bottom = self._get_monitor_rect(
-            x_widget + w_widget // 2, y_widget + h_widget // 2
-        )
+        try:
+            mon_left, mon_top, mon_right, mon_bottom = get_monitor_info(
+                self._widget.winfo_pointerx(), self._widget.winfo_pointery()
+            )
+        except Exception:
+            mon_left = 0
+            mon_top = 0
+            mon_right = self.winfo_vrootwidth()
+            mon_bottom = self.winfo_vrootheight()
         x_offset = self._apply_scaling(self._theme_tt_info["x_offset"])
         y_offset = self._apply_scaling(self._theme_tt_info["y_offset"])
         anchor = self._theme_tt_info["anchor"]

--- a/customtkinter/windows/widgets/utility/__init__.py
+++ b/customtkinter/windows/widgets/utility/__init__.py
@@ -5,3 +5,4 @@ from .utility_functions import parse_geometry_string
 from .utility_functions import get_window_root_of_widget
 from .utility_functions import get_proper_cursor
 from .utility_functions import get_width_height_from_orientation
+from .utility_functions import get_monitor_info

--- a/customtkinter/windows/widgets/utility/utility_functions.py
+++ b/customtkinter/windows/widgets/utility/utility_functions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
 import tkinter
 import sys
 import re
@@ -90,3 +92,49 @@ def get_width_height_from_orientation(orientation: Literal["horizontal", "vertic
         width = length
         height = thickness
     return width, height
+
+
+def get_monitor_info(x: int, y: int) -> tuple[int, int, int, int]:
+    """Return (left, top, right, bottom) of the physical monitor containing (x, y).
+
+    Raises NotImplementedError on Linux.
+    """
+    if sys.platform.startswith("win"):
+        from ctypes import windll, wintypes, Structure, byref
+
+        class _RECT(Structure):
+            _fields_ = [("left", wintypes.LONG), ("top", wintypes.LONG),
+                        ("right", wintypes.LONG), ("bottom", wintypes.LONG)]
+
+        class _MONITORINFO(Structure):
+            _fields_ = [("cbSize", wintypes.DWORD), ("rcMonitor", _RECT),
+                        ("rcWork", _RECT), ("dwFlags", wintypes.DWORD)]
+
+        pt = wintypes.POINT()
+        pt.x, pt.y = x, y
+        monitor = windll.user32.MonitorFromPoint(pt, 2)  # MONITOR_DEFAULTTONEAREST
+        info = _MONITORINFO()
+        info.cbSize = ctypes.sizeof(_MONITORINFO)
+        windll.user32.GetMonitorInfoW(monitor, byref(info))
+        r = info.rcMonitor
+        return r.left, r.top, r.right, r.bottom
+
+    elif sys.platform == "darwin":
+        CG = ctypes.cdll.LoadLibrary(
+            ctypes.util.find_library("CoreGraphics")
+            or "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+        )
+        CGPoint = ctypes.c_double * 2
+        point = CGPoint(float(x), float(y))
+        display_ids = (ctypes.c_uint32 * 8)()
+        count = ctypes.c_uint32(0)
+        CG.CGGetDisplaysWithPoint.restype = ctypes.c_int
+        CG.CGGetDisplaysWithPoint(point, 8, display_ids, ctypes.byref(count))
+        display = display_ids[0] if count.value > 0 else CG.CGMainDisplayID()
+        CG.CGDisplayBounds.restype = ctypes.c_double * 4
+        bounds = CG.CGDisplayBounds(display)
+        lft, top, w, h = float(bounds[0]), float(bounds[1]), float(bounds[2]), float(bounds[3])
+        return int(lft), int(top), int(lft + w), int(top + h)
+
+    else:
+        raise NotImplementedError(f"get_monitor_info is not supported on {sys.platform}")

--- a/customtkinter/windows/widgets/utility/utility_functions.py
+++ b/customtkinter/windows/widgets/utility/utility_functions.py
@@ -124,17 +124,32 @@ def get_monitor_info(x: int, y: int) -> tuple[int, int, int, int]:
             ctypes.util.find_library("CoreGraphics")
             or "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
         )
-        CGPoint = ctypes.c_double * 2
-        point = CGPoint(float(x), float(y))
+
+        class _CGPoint(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double)]
+
+        class _CGSize(ctypes.Structure):
+            _fields_ = [("width", ctypes.c_double), ("height", ctypes.c_double)]
+
+        class _CGRect(ctypes.Structure):
+            _fields_ = [("origin", _CGPoint), ("size", _CGSize)]
+
         display_ids = (ctypes.c_uint32 * 8)()
         count = ctypes.c_uint32(0)
         CG.CGGetDisplaysWithPoint.restype = ctypes.c_int
-        CG.CGGetDisplaysWithPoint(point, 8, display_ids, ctypes.byref(count))
+        CG.CGGetDisplaysWithPoint.argtypes = [
+            _CGPoint, ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32),
+        ]
+        CG.CGGetDisplaysWithPoint(
+            _CGPoint(float(x), float(y)), 8, display_ids, ctypes.byref(count)
+        )
         display = display_ids[0] if count.value > 0 else CG.CGMainDisplayID()
-        CG.CGDisplayBounds.restype = ctypes.c_double * 4
-        bounds = CG.CGDisplayBounds(display)
-        lft, top, w, h = float(bounds[0]), float(bounds[1]), float(bounds[2]), float(bounds[3])
-        return int(lft), int(top), int(lft + w), int(top + h)
+        CG.CGDisplayBounds.restype = _CGRect
+        CG.CGDisplayBounds.argtypes = [ctypes.c_uint32]
+        rect = CG.CGDisplayBounds(display)
+        lft, top = rect.origin.x, rect.origin.y
+        return int(lft), int(top), int(lft + rect.size.width), int(top + rect.size.height)
 
     else:
         raise NotImplementedError(f"get_monitor_info is not supported on {sys.platform}")


### PR DESCRIPTION
Adds multi-monitor awareness to the tooltip location code and tries if possible to keep the tooltip on the same monitor as the underlying widget