### PR TITLE
MacOS + Tcl/Tk 9.x Transparency fix

### DIFF
--- a/customtkinter/windows/widgets/ctk_floating_frame.py
+++ b/customtkinter/windows/widgets/ctk_floating_frame.py
@@ -133,7 +133,7 @@ class CTkFloatingFrame(CTkFrame):
         self._toplevel.geometry(f"{width}x{height}+{x_root - x_delta}+{y_root - y_delta}",
                                 apply_scaling=False)
         self._toplevel.deiconify()
-        if tkinter.TkVersion >= 9.0: #necessary to achieve transparent edges due to changes in Tk 9.x on MacOS
+        if tkinter.TkVersion >= 9.0 and sys.platform.startswith("darwin"): #necessary to achieve transparent edges due to changes in Tk 9.x on MacOS
             self._toplevel.wm_attributes(stylemask=('fullsizecontent','titled'))
 
     def close(self) -> None:

--- a/customtkinter/windows/widgets/ctk_floating_frame.py
+++ b/customtkinter/windows/widgets/ctk_floating_frame.py
@@ -60,7 +60,7 @@ class CTkFloatingFrame(CTkFrame):
             self._toplevel.attributes("-toolwindow", True) # removes icon from taskbar
         elif sys.platform.startswith("darwin"):
             if tkinter.TkVersion >= 9.0: #necessary to achieve transparent edges due to changes in Tk 9.x on MacOS
-                self._toplevel.wm_attributes(stylemask=('fullsizecontent'))
+                self._toplevel.wm_attributes(stylemask=('fullsizecontent','titled'))
                 self._toplevel.title("")
                 self._theme_ff_info["corner_radius"] = 0
             else:

--- a/customtkinter/windows/widgets/ctk_floating_frame.py
+++ b/customtkinter/windows/widgets/ctk_floating_frame.py
@@ -53,17 +53,23 @@ class CTkFloatingFrame(CTkFrame):
         self._toplevel.attributes("-topmost", True)
         self._toplevel.attributes("-alpha", 1.0 - self._theme_ff_info["transparency"])
         self._toplevel.resizable(width=True, height=True)
-        self._toplevel.overrideredirect(True)
 
         if sys.platform.startswith("win"):
+            self._toplevel.overrideredirect(True)
             self._toplevel.attributes("-transparentcolor", self._apply_appearance_mode(self.transparent_color))
             self._toplevel.attributes("-toolwindow", True) # removes icon from taskbar
         elif sys.platform.startswith("darwin"):
-            self.transparent_color = "systemTransparent"
-            self._toplevel.attributes("-transparent", True)
-            self._toplevel.wm_attributes(stylemask=("fullsizecontent", "titled"))
+            if tkinter.TkVersion >= 9.0: #necessary to achieve transparent edges due to changes in Tk 9.x on MacOS
+                self._toplevel.wm_attributes(stylemask=('fullsizecontent'))
+                self._toplevel.title("")
+                self._theme_ff_info["corner_radius"] = 0
+            else:
+                self._toplevel.overrideredirect(True)
+                self.transparent_color = "systemTransparent"
+                self._toplevel.attributes("-transparent", True)
         else:
             #Linux doesn't support transparency, so we force the frame to cover all available space
+            self._toplevel.overrideredirect(True)
             self._theme_ff_info["corner_radius"] = 0
 
         # frame
@@ -127,6 +133,8 @@ class CTkFloatingFrame(CTkFrame):
         self._toplevel.geometry(f"{width}x{height}+{x_root - x_delta}+{y_root - y_delta}",
                                 apply_scaling=False)
         self._toplevel.deiconify()
+        if tkinter.TkVersion >= 9.0: #necessary to achieve transparent edges due to changes in Tk 9.x on MacOS
+            self._toplevel.wm_attributes(stylemask=('fullsizecontent','titled'))
 
     def close(self) -> None:
         """ Hides the widget. """

--- a/customtkinter/windows/widgets/ctk_floating_frame.py
+++ b/customtkinter/windows/widgets/ctk_floating_frame.py
@@ -61,6 +61,7 @@ class CTkFloatingFrame(CTkFrame):
         elif sys.platform.startswith("darwin"):
             self.transparent_color = "systemTransparent"
             self._toplevel.attributes("-transparent", True)
+            self._toplevel.wm_attributes(stylemask=("fullsizecontent", "titled"))
         else:
             #Linux doesn't support transparency, so we force the frame to cover all available space
             self._theme_ff_info["corner_radius"] = 0


### PR DESCRIPTION
Due to changes in Tcl/Tk 9.x, transparency no longer works the same way on MacOS. Without this patch or another solution, custom2kinter rounded tooltips will look like this:

<img width="562" height="462" alt="image" src="https://github.com/user-attachments/assets/bce9a7cd-7c70-41d9-9243-aaa2a718f719" />

This PR proposes a solution, but perhaps a less hackish workaround can be found.

Relates to #3 and also discussed [here](https://github.com/python/cpython/issues/124111#issuecomment-4722579612).