### PR TITLE
Restores Tk-compatible bg and background aliases for CTk.configure

### DIFF
--- a/customtkinter/windows/ctk_tk.py
+++ b/customtkinter/windows/ctk_tk.py
@@ -243,6 +243,11 @@ class CTk(tkinter.Tk, CTkAppearanceModeBaseClass, CTkScalingBaseClass, CTkContai
             return geometry_string
 
     def configure(self, **kwargs: Unpack[CTkArgs]) -> None:
+        if "bg" in kwargs:
+            kwargs["fg_color"] = kwargs.pop("bg")
+        if "background" in kwargs:
+            kwargs["fg_color"] = kwargs.pop("background")
+
         if "fg_color" in kwargs:
             self._fg_color = self._check_color_type(kwargs.pop("fg_color"))
             self._theme_info["fg_color"] = self._fg_color


### PR DESCRIPTION
I've started running this code through updated unit tests based on my https://github.com/ajkessel/Custom2kinter/tree/m1-test-foundation branch. I will eventually propose those branch as a PR, but first I wanted to get some fixes through that the unit tests have surfaced.

This PR restores Tk-compatible bg and background aliases for CTk.configure(). These now route through the existing fg_color handling path, so cget("fg_color"), cget("bg"), appearance-mode color application, and child color propagation stay consistent.