### PR TITLE
Keep widget theme metadata synchronized when width or height are changed via configure

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/ctk_widget.py
+++ b/customtkinter/windows/widgets/core_widget_classes/ctk_widget.py
@@ -196,8 +196,12 @@ class CTkWidget(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBaseClass, 
         """ Called when desired dimensions change """
         if width is not None:
             self._desired_width = width
+            if "width" in getattr(self, "_theme_info", {}):
+                self._theme_info["width"] = width
         if height is not None:
             self._desired_height = height
+            if "height" in getattr(self, "_theme_info", {}):
+                self._theme_info["height"] = height
 
         super().configure(width=self._apply_scaling(self._desired_width),
                           height=self._apply_scaling(self._desired_height))


### PR DESCRIPTION
I've started running this code through updated unit tests based on my [https://github.com/ajkessel/Custom2kinter/tree/m1-test-foundation](m1-test-foundation) branch. I will eventually propose those branch as a PR, but first I wanted to get some fixes through that the unit tests have surfaced.

This PR keeps widget theme metadata synchronized when width or height are changed via configure(). This fixes cget("width") / cget("height") returning stale constructor or theme defaults for widgets like CTkButton, CTkLabel, CTkFrame, and CTkEntry after resizing.